### PR TITLE
위치 서비스 로직 리팩토링

### DIFF
--- a/src/components/meeting/MeetingNav.jsx
+++ b/src/components/meeting/MeetingNav.jsx
@@ -13,23 +13,26 @@ import AlarmModal from 'components/common/AlarmModal';
 const MeetingNav = () => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
-  const { alarmModal } = useSelector(({ modal }) => modal);
+  const { alarmModal } = useSelector(({ modal }) => modal.alarmModal);
   const { location, error, loading } = useCurrentLocation();
   const { searchParams } = useCurrentQuery();
 
   const { sort } = searchParams;
 
-  const handleNearbyMeetingNavigate = () => {
-    if (!location || error) {
+  const handleLocationCheck = () => {
+    if (!location || error || loading) {
       dispatch(toggleModal({ target: 'alarmModal', visible: true }));
-      return;
+      return false;
     }
-    if (loading) {
-      dispatch(toggleModal({ target: 'alarmModal', visible: true }));
-      return;
-    }
+    return true;
+  };
 
-    navigate(`/meeting?sort=near&lon=${location?.lon}&lat=${location?.lat}`);
+  const handleNearbyMeetingNavigate = () => {
+    const locationData = handleLocationCheck();
+
+    if (locationData) {
+      navigate(`/meeting?sort=near&lon=${location?.lon}&lat=${location?.lat}`);
+    }
   };
 
   const handleModalClose = () => {

--- a/src/hooks/useCurrentLocation.js
+++ b/src/hooks/useCurrentLocation.js
@@ -1,8 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 
-import { toggleModal } from 'redux/modules/modal';
-
 const useCurrentLocation = () => {
   const dispatch = useDispatch();
   const [location, setLocation] = useState();
@@ -36,6 +34,8 @@ const useCurrentLocation = () => {
     };
     // 현재 디바이스의 경도, 위도를 가져옴
     handleLoadLocation();
+
+    return () => handleLoadLocation();
   }, [dispatch]);
 
   return { location, error, loading };


### PR DESCRIPTION
위치 정보 커스텀 훅 컴포넌트 언마운트 시 뒷정리 함수 구현 => 위치 정보를 가져오는 도중 다른 페이지 이동 시 메모리 누수 발생 방지를 위함

모임 네비게이션 컴포넌트 근처 모임 페이지 이동 시 위치 정보 확인 함수 구현하여 확인 후 이동하게끔 수정

resolved : #155 