### PR TITLE
모임 지도 관심사 별 로직 분리

### DIFF
--- a/src/components/meeting/MeetingMap.jsx
+++ b/src/components/meeting/MeetingMap.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
 

--- a/src/components/meeting/MeetingMap.jsx
+++ b/src/components/meeting/MeetingMap.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
 
@@ -6,129 +6,145 @@ import { changeLocation } from 'redux/modules/meeting';
 import useMeetingQuery from 'hooks/useMeetingQuery';
 import useCurrentLocation from 'hooks/useCurrentLocation';
 
+const { kakao } = window;
+
 const MeetingMap = ({ keyword }) => {
   const dispatch = useDispatch();
   const { meetingInfo } = useMeetingQuery();
-  const { location, loading, error } = useCurrentLocation();
+  const { location, loading } = useCurrentLocation();
+  const [kakaoMap, setKakaoMap] = useState(null);
+  const container = useRef();
 
+  // 위치 서비스 정보에 따라 지도 생성
   useEffect(() => {
-    const { kakao } = window;
+    // 위치 서비스를 가져오는 중이라면 실행하지 않음
+    if (loading) return;
 
-    const infowindow = new kakao.maps.InfoWindow({ zIndex: 1 });
-    const container = document.getElementById('map');
-    let selectedMarker = null;
-
-    const handleKakaoMapCreate = (position) => {
-      const { longitude: lon, latitude: lat } = position.coords;
-
-      const options = {
-        center: new kakao.maps.LatLng(lat, lon),
-        level: 5,
-      };
-
-      const map = new kakao.maps.Map(container, options);
-      const ps = new window.kakao.maps.services.Places();
-
-      // 선택된 마커 이미지 설정
-      const selectedImgSrc =
-        'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/markerStar.png';
-      const imgSize = new kakao.maps.Size(24, 35);
-      const selectedMarkerImg = new kakao.maps.MarkerImage(
-        selectedImgSrc,
-        imgSize,
-      );
-
-      // 줌 컨트롤러 생성
-      const zoomControl = new kakao.maps.ZoomControl();
-      map.addControl(zoomControl, kakao.maps.ControlPosition.RIGHT);
-
-      // 마커와 인포 윈도우를 표시하는 함수
-      const handleMarkerDisplay = (place) => {
-        let marker = new kakao.maps.Marker({
-          map,
-          position: new kakao.maps.LatLng(place.y, place.x),
-          clickable: true,
-        });
-
-        // 마커에 호버 시 인포 윈도우 디스플레이
-        kakao.maps.event.addListener(marker, 'mouseover', () => {
-          infowindow.setContent(
-            '<div style="padding:3px;font-size:12px;">' +
-              place.place_name +
-              '</div>',
-          );
-          infowindow.open(map, marker);
-        });
-
-        // 마커 클릭 시 선택된 마커 이미지 변경 및 정보 얻기
-        kakao.maps.event.addListener(marker, 'click', () => {
-          // 마커 이미지 변경
-          if (!selectedMarker || selectedMarker !== marker) {
-            selectedMarker &&
-              selectedMarker.setImage(selectedMarker.normalImage);
-
-            marker.setImage(selectedMarkerImg);
-          }
-
-          selectedMarker = marker;
-
-          const location = {
-            placeName: place.place_name,
-            addressName: place.address_name,
-            coordinates: [place.x, place.y],
-          };
-          dispatch(changeLocation(location));
-        });
-      };
-
-      // 검색어가 입력되면 실행될 콜백 함수
-      const handleSearchCallback = (data, status, pagination) => {
-        if (status === kakao.maps.services.Status.OK) {
-          let bounds = new kakao.maps.LatLngBounds();
-          for (let i = 0; i < data.length; i++) {
-            handleMarkerDisplay(data[i]);
-            bounds.extend(new kakao.maps.LatLng(data[i].y, data[i].x));
-          }
-          map.setBounds(bounds);
-        }
-      };
-
-      // 검색어가 존재하지 않으면 현재 위치를 보여줌
-      if (!keyword) return;
-      console.log('키워드로 검색');
-      ps.keywordSearch(keyword, handleSearchCallback);
+    const options = {
+      center: location
+        ? new kakao.maps.LatLng(location.lat, location.lon)
+        : new kakao.maps.LatLng('37.5666805', '126.9784147'),
+      level: 5,
     };
 
-    // 모임 정보가 존재하면 모임 정보를 바탕으로 지도 초기 위치 설정
-    if (meetingInfo) {
-      const position = {
-        coords: {
-          longitude: meetingInfo.location.coordinates[0],
-          latitude: meetingInfo.location.coordinates[1],
-        },
-      };
-      handleKakaoMapCreate(position);
-    } else {
-      // 위치 정보가 허용 되어있으면 현재 위치, 아니면 서울 시청을 보여줌
-      if (!loading && location) {
-        handleKakaoMapCreate({
-          coords: {
-            longitude: location.lon,
-            latitude: location.lat,
-          },
-        });
-      } else if (error) {
-        handleKakaoMapCreate({
-          coords: {
-            longitude: '126.9784147',
-            latitude: '37.5666805',
-          },
-        });
-      }
-    }
-  }, [keyword, dispatch, meetingInfo, loading, location, error]);
+    const zoomControl = new kakao.maps.ZoomControl();
 
-  return <MapWrapper id="map"></MapWrapper>;
+    const map = new kakao.maps.Map(container.current, options);
+    map.addControl(zoomControl, kakao.maps.ControlPosition.RIGHT);
+
+    setKakaoMap(map);
+  }, [location, loading]);
+
+  // 모임 위치에 따라 지도 중심위치 이동 및 마커, 인포윈도우 생성
+  useEffect(() => {
+    if (!kakaoMap || !meetingInfo) return;
+
+    const selectedImgSrc =
+      'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/markerStar.png';
+    const imgSize = new kakao.maps.Size(24, 35);
+    const selectedMarkerImg = new kakao.maps.MarkerImage(
+      selectedImgSrc,
+      imgSize,
+    );
+
+    const meetingLocation = new kakao.maps.LatLng(
+      meetingInfo.location.coordinates[1],
+      meetingInfo.location.coordinates[0],
+    );
+
+    // 마커와 인포 윈도우를 생성하는 함수
+    const infowindow = new kakao.maps.InfoWindow({
+      position: meetingLocation,
+      zIndex: 1,
+      content: `<div style="padding:3px;font-size:12px;">${meetingInfo.location.placeName}</div>`,
+    });
+
+    const marker = new kakao.maps.Marker({
+      kakaoMap,
+      position: meetingLocation,
+      clickable: true,
+    });
+
+    marker.setImage(selectedMarkerImg);
+    marker.setMap(kakaoMap);
+    infowindow.open(kakaoMap, marker);
+    kakaoMap.setCenter(meetingLocation);
+  }, [meetingInfo]);
+
+  useEffect(() => {
+    if (!kakaoMap || !keyword) return;
+
+    const infowindow = new kakao.maps.InfoWindow({ zIndex: 1 });
+    const selectedImgSrc =
+      'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/markerStar.png';
+    const imgSize = new kakao.maps.Size(24, 35);
+    const selectedMarkerImg = new kakao.maps.MarkerImage(
+      selectedImgSrc,
+      imgSize,
+    );
+    let selectedMarker = null;
+
+    const handleMarkerHover = (marker, place) => {
+      // 마커에 호버 시 인포 윈도우 디스플레이
+      kakao.maps.event.addListener(marker, 'mouseover', () => {
+        infowindow.setContent(
+          `<div style="padding:3px;font-size:12px;">${place.place_name}</div>`,
+        );
+        infowindow.open(kakaoMap, marker);
+      });
+    };
+
+    // 선택된 마커의 이미지를 변경하고 정보를 얻는 함수
+    const handleGetMarkerData = (marker, place) => {
+      kakao.maps.event.addListener(marker, 'click', () => {
+        if (!selectedMarker || selectedMarker !== marker) {
+          selectedMarker && selectedMarker.setImage(selectedMarker.normalImage);
+          marker.setImage(selectedMarkerImg);
+        }
+        selectedMarker = marker;
+
+        const location = {
+          placeName: place.place_name,
+          addressName: place.address_name,
+          coordinates: [place.x, place.y],
+        };
+
+        dispatch(changeLocation(location));
+      });
+    };
+
+    const handleMarkerDisplay = (place) => {
+      const marker = new kakao.maps.Marker({
+        kakaoMap,
+        position: new kakao.maps.LatLng(place.y, place.x),
+        clickable: true,
+      });
+
+      marker.setMap(kakaoMap);
+
+      handleMarkerHover(marker, place);
+      handleGetMarkerData(marker, place);
+    };
+
+    // 검색어가 입력되면 실행될 콜백
+    const handleSearchCallback = (data, status) => {
+      if (status === kakao.maps.services.Status.OK) {
+        const bounds = new kakao.maps.LatLngBounds();
+        data.forEach((item) => {
+          handleMarkerDisplay(item);
+          bounds.extend(new kakao.maps.LatLng(item.y, item.x));
+        });
+        kakaoMap.setBounds(bounds);
+      }
+    };
+
+    const ps = new kakao.maps.services.Places();
+    ps.keywordSearch(keyword, handleSearchCallback);
+
+    // return () => handleMarkerDisplay;
+  }, [keyword, dispatch]);
+
+  return <MapWrapper id="map" ref={container}></MapWrapper>;
 };
 
 const MapWrapper = styled.div`

--- a/src/hooks/useCurrentLocation.js
+++ b/src/hooks/useCurrentLocation.js
@@ -35,7 +35,7 @@ const useCurrentLocation = () => {
     // 현재 디바이스의 경도, 위도를 가져옴
     handleLoadLocation();
 
-    return () => handleLoadLocation();
+    return handleLoadLocation;
   }, [dispatch]);
 
   return { location, error, loading };


### PR DESCRIPTION
기존 하나의 effect에서 처리하던 로직을 관심사 별로 분리

1. 지도 초기 생성 : 위치 정보 여부에 따라 생성
2. 모임 정보를 바탕으로 지도 마커, 인포 윈도우 표시
3. 키워드 검색 시, 해당 키워드 마커 표시 및 마커 hover 시 인포윈도우 생성, 마커 click 시 마커 디자인 변경

resolved : #160 